### PR TITLE
Retain focus when opening Marked window

### DIFF
--- a/plugin/marked.vim
+++ b/plugin/marked.vim
@@ -12,7 +12,7 @@ let s:save_cpo = &cpo
 set cpo&vim
 
 function s:OpenMarked()
-  silent exe "!open -a Marked.app '%:p'"
+  silent exe "!open -a Marked.app -g '%:p'"
   silent exe "augroup marked_autoclose_".expand("%:p")
     autocmd!
     silent exe 'autocmd VimLeavePre * call s:QuitMarked("'.expand("%:p").'")'


### PR DESCRIPTION
Great plugin!

I would prefer if Marked didn't take focus from the editor window, and this little change does that.

Of course, if you like it the way it is, I understand :)
