### PR TITLE
Add `:MarkedOpen!`

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -6,7 +6,9 @@ Open the current Markdown buffer in [Marked.app](http://markedapp.com/).
 
 This plugin adds the following commands to Markdown buffers:
 
-    :MarkedOpen    Open the current Markdown buffer in Marked.app.
+    :MarkedOpen[!] Open the current Markdown buffer in Marked.app.
+                   Call with a bang to prevent Marked.app from stealing
+                   focus from Vim.
 
     :MarkedQuit    Close the current Markdown buffer in Marked.app.
                    Quit Marked.app if no other documents are open.

--- a/plugin/marked.vim
+++ b/plugin/marked.vim
@@ -11,8 +11,9 @@ let g:marked_loaded = 1
 let s:save_cpo = &cpo
 set cpo&vim
 
-function s:OpenMarked()
-  silent exe "!open -a Marked.app '%:p'"
+function s:OpenMarked(background)
+  silent exe "!open -a Marked.app ".(a:background ? '-g' : '')." '%:p'"
+
   silent exe "augroup marked_autoclose_".expand("%:p")
     autocmd!
     silent exe 'autocmd VimLeavePre * call s:QuitMarked("'.expand("%:p").'")'
@@ -43,7 +44,7 @@ endfunction
 
 augroup marked_commands
   autocmd!
-  autocmd Filetype markdown command! -buffer MarkedOpen :call s:OpenMarked()
+  autocmd FileType markdown command! -buffer -bang MarkedOpen :call s:OpenMarked(<bang>0)
   autocmd FileType markdown command! -buffer MarkedQuit :call s:QuitMarked(expand('%:p'))
 augroup END
 


### PR DESCRIPTION
This will prevent Marked.app from stealing focus from Vim.
