### PR TITLE
Don't load the plugin if it's not running on OSX

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -17,6 +17,9 @@ This plugin adds the following commands to Markdown buffers:
 If you run `:MarkedOpen`, the document in Marked will be automatically closed
 when Vim exists, and Marked will quit if no other documents are open.
 
+**Note** if you're not on OSX, the plugin won't be loaded and the `:MarkedOpen`
+and `:MarkedQuit` commands won't be available.
+
 ## Configuration
 
 By default, this plugin is configred to use Marked 2. If you are still using

--- a/plugin/marked.vim
+++ b/plugin/marked.vim
@@ -4,6 +4,11 @@
 " Version: 0.5.0
 " License: Same as Vim itself (see :help license)
 
+" Don't do anything if we're not on OSX.
+if !has('unix') || !(system('uname -s') == "Darwin\n")
+  finish
+endif
+
 if &cp || exists("g:marked_loaded") && g:marked_loaded
   finish
 endif


### PR DESCRIPTION
Since Marked is _very_ OSX-specific (meaning it's only available for OSX), it's nice to avoid cluttering Linux users with Marked-related commands.
