### PR TITLE
Also enable it in vimwiki mode

### DIFF
--- a/plugin/marked.vim
+++ b/plugin/marked.vim
@@ -63,9 +63,9 @@ endfunction
 
 augroup marked_commands
   autocmd!
-  autocmd FileType markdown,mkd,ghmarkdown command! -buffer -bang MarkedOpen :call s:OpenMarked(<bang>0)
-  autocmd FileType markdown,mkd,ghmarkdown command! -buffer MarkedQuit :call s:QuitMarked(expand('%:p'))
-  autocmd FileType markdown,mkd,ghmarkdown command! -buffer -bang MarkedToggle :call s:ToggleMarked(<bang>0, expand('%:p'))
+  autocmd FileType markdown,mkd,ghmarkdown,vimwiki command! -buffer -bang MarkedOpen :call s:OpenMarked(<bang>0)
+  autocmd FileType markdown,mkd,ghmarkdown,vimwiki command! -buffer MarkedQuit :call s:QuitMarked(expand('%:p'))
+  autocmd FileType markdown,mkd,ghmarkdown,vimwiki command! -buffer -bang MarkedToggle :call s:ToggleMarked(<bang>0, expand('%:p'))
   autocmd VimLeavePre * call s:QuitAll()
 augroup END
 


### PR DESCRIPTION
I'm using vimwiki in markdown mode. However, the marked plugin doesn't kick in when in vimwiki mode. Added it to the list of modes