### PR TITLE
Refactor for Marked 2 exclusively

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2019 Joshua Priddle <jpriddle@me.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.markdown
+++ b/README.markdown
@@ -62,6 +62,16 @@ following to your `vimrc`:
 let g:marked_autoquit = 0
 ```
 
+**`MarkedSetup()`**
+
+Vim function to initialize this plugin. Useful for cases where you want to
+work with Marked based on a specific filename. For example, to activate the
+plugin for `LICENSE` files, add the following to your `vimrc`:
+
+```
+autocmd BufNewFile,BufRead LICENSE call MarkedSetup()
+```
+
 ## License
 
 MIT License - see [`LICENSE`](./LICENSE) in this repo.

--- a/README.markdown
+++ b/README.markdown
@@ -1,17 +1,11 @@
 # marked.vim
 
-Open the current Markdown buffer in [Marked](http://markedapp.com/). Supports
-Marked 1 and 2.
+Open the current Markdown buffer in [Marked 2](http://marked2app.com/).
 
 **Note**: Since Marked is available only for OS X, this plugin will not be loaded
 unless you are on OS X.
 
 ## Configuration
-
-By default, this plugin is configred to use Marked 2. If you are still using
-Marked version 1, set the following in your `~/.vimrc`:
-
-    let g:marked_app = "Marked"
 
 If you need to enable the plugin for custom Vim FileTypes:
 
@@ -23,15 +17,18 @@ This plugin adds the following commands to Markdown buffers:
 
     :MarkedOpen[!]          Open the current Markdown buffer in Marked. Call with
                             a bang to prevent Marked from stealing focus from Vim.
-                            Documents opened in Marked are tracked and closed
-                            automatically when you quit Vim.
 
-    :MarkedQuit             Close the current Markdown buffer in Marked. Quits
-                            Marked if there are no other documents open.
+    :MarkedQuit[!]          Close the Marked document corresponding to the
+                            current buffer. Quits Marked if there are no othe
+                            documents open. Call with a bang to immediately
+                            quit Marked (and any open documents).
 
     :MarkedToggle[!]        If the current Markdown buffer is already open in
-                            Marked, calls :MarkedQuit. If not, calls
+                            Marked, calls :MarkedQuit[!]. If not, calls
                             :MarkedOpen[!].
+
+    :MarkedPreview          Send the current range (defaults to the entire
+                            buffer) to Marked as a preview.
 
 ## License
 

--- a/README.markdown
+++ b/README.markdown
@@ -1,34 +1,66 @@
 # marked.vim
 
-Open the current Markdown buffer in [Marked 2](http://marked2app.com/).
+Vim plugin for [Marked 2](http://marked2app.com), a previewer for Markdown
+files.
 
-**Note**: Since Marked is available only for OS X, this plugin will not be loaded
-unless you are on OS X.
+Adds `:MarkedOpen`, `:MarkedQuit`, `:MarkedToggle`, and `:MarkedPreview`
+commands to Markdown buffers, allowing you to quickly open, close, and preview
+content in Marked 2.
 
-## Configuration
-
-If you need to enable the plugin for custom Vim FileTypes:
-
-    let g:marked_filetypes = ["markdown", "mkd", "ghmarkdown", "vimwiki"]
+**Note**: Since Marked is available only for macOS, this plugin will is not
+loaded under other operating systems.
 
 ## Usage
 
-This plugin adds the following commands to Markdown buffers:
+This plugin adds the following commands to Markdown buffers (see
+`g:marked_filetypes` below to add more FileTypes):
 
-    :MarkedOpen[!]          Open the current Markdown buffer in Marked. Call with
-                            a bang to prevent Marked from stealing focus from Vim.
+```
+:MarkedOpen[!]
+```
 
-    :MarkedQuit[!]          Close the Marked document corresponding to the
-                            current buffer. Quits Marked if there are no othe
-                            documents open. Call with a bang to immediately
-                            quit Marked (and any open documents).
+Open the current Markdown file in Marked. Call with a bang to prevent Marked
+from stealing focus from Vim.
 
-    :MarkedToggle[!]        If the current Markdown buffer is already open in
-                            Marked, calls :MarkedQuit[!]. If not, calls
-                            :MarkedOpen[!].
+```
+:MarkedQuit[!]
+```
 
-    :MarkedPreview          Send the current range (defaults to the entire
-                            buffer) to Marked as a preview.
+Close the Marked document corresponding to the current Markdown file. Call
+with a bang to quit Marked completely.
+
+```
+:MarkedToggle[!]
+```
+
+If the current Markdown file is already open in Marked, same as
+`:MarkedQuit[!]`. If not, same as `:MarkedOpen[!]`.
+
+```
+:[range]MarkedPreview
+```
+
+Send the current range (defaults to the enture buffer) to Marked as a preview.
+
+## Configuration
+
+**`g:marked_filetypes`**
+
+Vim FileTypes that can be opened by Marked and will load this plugin. The
+default is as follows and can be customized in your `vimrc` if necessary:
+
+```
+let g:marked_filetypes = ["markdown", "mkd", "ghmarkdown", "vimwiki"]
+```
+
+**`g:marked_autoquit`**
+
+If true, quit Marked when Vim exits. Default is true. To disable, add the
+following to your `vimrc`:
+
+```
+let g:marked_autoquit = 0
+```
 
 ## License
 

--- a/README.markdown
+++ b/README.markdown
@@ -32,4 +32,4 @@ This plugin adds the following commands to Markdown buffers:
 
 ## License
 
-Same as Vim itself, see `:help license`.
+MIT License - see [`LICENSE`](./LICENSE) in this repo.

--- a/README.markdown
+++ b/README.markdown
@@ -1,11 +1,11 @@
 # marked.vim
 
-Vim plugin for [Marked 2](http://marked2app.com), a previewer for Markdown
-files.
+Vim plugin for [Marked](http://marked2app.com), a previewer for Markdown
+files. Supports Marked 1 and 2.
 
 Adds `:MarkedOpen`, `:MarkedQuit`, `:MarkedToggle`, and `:MarkedPreview`
 commands to Markdown buffers, allowing you to quickly open, close, and preview
-content in Marked 2.
+content in Marked.
 
 **Note**: Since Marked is available only for macOS, this plugin will is not
 loaded under other operating systems.
@@ -44,6 +44,15 @@ Send the current range (defaults to the enture buffer) to Marked as a preview.
 Call with a bang to prevent Marked from stealing focus from Vim.
 
 ## Configuration
+
+**`g:marked_app`**
+
+The Marked application name. By default this is "Marked 2". If you are still
+using Marked.app version 1, add the following to your `vimrc`:
+
+```
+let g:marked_app = "Marked"
+```
 
 **`g:marked_filetypes`**
 

--- a/README.markdown
+++ b/README.markdown
@@ -37,10 +37,11 @@ If the current Markdown file is already open in Marked, same as
 `:MarkedQuit[!]`. If not, same as `:MarkedOpen[!]`.
 
 ```
-:[range]MarkedPreview
+:[range]MarkedPreview[!]
 ```
 
 Send the current range (defaults to the enture buffer) to Marked as a preview.
+Call with a bang to prevent Marked from stealing focus from Vim.
 
 ## Configuration
 

--- a/doc/marked.txt
+++ b/doc/marked.txt
@@ -6,8 +6,9 @@ License: Same terms as Vim itself (see |license|)
 ==============================================================================
 INTRODUCTION                                    *marked*
 
-marked.vim adds `:MarkedOpen`, `:MarkedQuit` and `:MarkedToggle` commands to
-Markdown buffers.
+marked.vim adds `:MarkedOpen`, `:MarkedQuit`, `:MarkedToggle`, and
+`:MarkedPreview` commands to Markdown buffers, allowing you to quickly open,
+close, and preview content in Marked 2.
 
 Note: Since Marked is available only for OS X, this plugin will not be loaded
 unless you are on OS X.
@@ -15,11 +16,6 @@ unless you are on OS X.
 ==============================================================================
 CONFIGURATION                                   *marked-configuration*
 
-                                                *g:marked_app*
-The Marked application name. By default this is "Marked 2". If you are still
-using Marked.app version 1, add the following to your |vimrc|: >
-    let g:marked_app = 'Marked'
-<
                                                 *g:marked_filetypes*
 Vim FileTypes that can be opened by Marked. If you need to customize, update
 the list in your |vimrc|: >
@@ -43,6 +39,9 @@ COMMANDS                                        *marked-commands*
                         Marked, same as :MarkedQuit. If not, same as
                         :MarkedOpen[!].
 
+                                                *marked-:MarkedPreview*
+:MarkedPreview[!]       Send the current rand (defaults to the enture buffer)
+                        to Marked as a preview.
 
 ==============================================================================
 ABOUT                                           *marked-about*

--- a/doc/marked.txt
+++ b/doc/marked.txt
@@ -1,6 +1,6 @@
 *marked.txt*  Open Markdown in Marked.
 Author: Joshua Priddle <jpriddle@me.com>
-License: MIT (see |vim-marked-license|)
+License: MIT (see |marked-license|)
 Version: 2.0.0
 
 This plugin is only available on macOS and if 'compatible' is not set.
@@ -77,7 +77,7 @@ Grab the latest version or report a bug on Github:
 https://github.com/itspriddle/vim-marked
 
 ==============================================================================
-LICENSE                                         *vim-marked-license*
+LICENSE                                         *marked-license*
 
 MIT License
 

--- a/doc/marked.txt
+++ b/doc/marked.txt
@@ -1,7 +1,7 @@
 *marked.vim*  Open the current Markdown buffer in Marked.app.
 
 Author: Joshua Priddle <jpriddle@me.com>
-License: Same terms as Vim itself (see |license|)
+License: MIT (see |vim-marked-license|)
 
 ==============================================================================
 INTRODUCTION                                    *marked*
@@ -49,6 +49,31 @@ ABOUT                                           *marked-about*
 Grab the latest version or report a bug on Github:
 
 https://github.com/itspriddle/vim-marked
+
+==============================================================================
+LICENSE                                         *vim-marked-license*
+
+MIT License
+
+Copyright (c) 2019 Joshua Priddle <jpriddle@me.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
 
 ==============================================================================
  vim:tw=78:et:ft=help:norl:

--- a/doc/marked.txt
+++ b/doc/marked.txt
@@ -55,6 +55,13 @@ If true, quit Marked when Vim exits. Default is true. To disable, add the
 following to your |vimrc|: >
     let g:marked_autoquit = 0
 <
+*MarkedSetup()*
+
+Vim function to initialize this plugin. Useful for cases where you want to
+work with Marked based on a specific filename. For example, to activate the
+plugin for `LICENSE` files, add the following to your |vimrc|: >
+    autocmd BufNewFile,BufRead LICENSE call MarkedSetup()
+<
 ==============================================================================
 ABOUT                                           *marked-about*
 

--- a/doc/marked.txt
+++ b/doc/marked.txt
@@ -36,9 +36,10 @@ with a bang to quit Marked completely.
 If the current Markdown file is already open in Marked, same as
 `:MarkedQuit[!]`. If not, same as `:MarkedOpen[!]`.
 
-:[range]MarkedPreview                          *marked-:MarkedPreview*
+:[range]MarkedPreview[!]                       *marked-:MarkedPreview*
 
 Send the current range (defaults to the enture buffer) to Marked as a preview.
+Call with a bang to prevent Marked from stealing focus from Vim.
 
 ==============================================================================
 CONFIGURATION                                   *marked-configuration*

--- a/doc/marked.txt
+++ b/doc/marked.txt
@@ -1,48 +1,60 @@
-*marked.vim*  Open the current Markdown buffer in Marked.app.
-
+*marked.txt*  Open Markdown in Marked 2.app.
 Author: Joshua Priddle <jpriddle@me.com>
 License: MIT (see |vim-marked-license|)
+Version: 2.0.0
+
+This plugin is only available on macOS and if 'compatible' is not set.
 
 ==============================================================================
 INTRODUCTION                                    *marked*
 
-marked.vim adds `:MarkedOpen`, `:MarkedQuit`, `:MarkedToggle`, and
-`:MarkedPreview` commands to Markdown buffers, allowing you to quickly open,
-close, and preview content in Marked 2.
+Vim plugin for Marked 2 (http://marked2app.com), a previewer for Markdown
+files.
 
-Note: Since Marked is available only for OS X, this plugin will not be loaded
-unless you are on OS X.
+Adds `:MarkedOpen`, `:MarkedQuit`, `:MarkedToggle`, and `:MarkedPreview`
+commands to Markdown buffers, allowing you to quickly open, close, and preview
+content in Marked 2.
+
+==============================================================================
+COMMANDS                                        *marked-commands*
+
+This plugin adds the following commands to Markdown buffers (see
+|g:marked_filetypes| to add more |FileTypes|):
+
+:MarkedOpen[!]                                  *marked-:MarkedOpen*
+
+Open the current Markdown file in Marked. Call with a bang to prevent Marked
+from stealing focus from Vim.
+
+:MarkedQuit[!]                                  *marked-:MarkedQuit*
+
+Close the Marked document corresponding to the current Markdown file. Call
+with a bang to quit Marked completely.
+
+:MarkedToggle[!]                                *marked-:MarkedToggle*
+
+If the current Markdown file is already open in Marked, same as
+`:MarkedQuit[!]`. If not, same as `:MarkedOpen[!]`.
+
+:[range]MarkedPreview                          *marked-:MarkedPreview*
+
+Send the current range (defaults to the enture buffer) to Marked as a preview.
 
 ==============================================================================
 CONFIGURATION                                   *marked-configuration*
 
-                                                *g:marked_filetypes*
-Vim FileTypes that can be opened by Marked. If you need to customize, update
-the list in your |vimrc|: >
+*g:marked_filetypes*
+
+Vim FileTypes that can be opened by Marked and will load this plugin. The
+default is as follows and can be customized in your |vimrc| if necessary: >
     let g:marked_filetypes = ["markdown", "mkd", "ghmarkdown", "vimwiki"]
 <
-==============================================================================
-COMMANDS                                        *marked-commands*
+*g:marked_autoquit*
 
-                                                *marked-:MarkedOpen*
-:MarkedOpen[!]          Open the current Markdown buffer in Marked. Call with
-                        a bang to prevent Marked from stealing focus from Vim.
-                        Documents opened in Marked are tracked and closed
-                        automatically when you quit Vim.
-
-                                                *marked-:MarkedQuit*
-:MarkedQuit             Close the current Markdown buffer in Marked. Quits
-                        Marked if there are no other documents open.
-
-                                                *marked-:MarkedToggle*
-:MarkedToggle[!]        If the current Markdown buffer is already open in
-                        Marked, same as :MarkedQuit. If not, same as
-                        :MarkedOpen[!].
-
-                                                *marked-:MarkedPreview*
-:MarkedPreview[!]       Send the current rand (defaults to the enture buffer)
-                        to Marked as a preview.
-
+If true, quit Marked when Vim exits. Default is true. To disable, add the
+following to your |vimrc|: >
+    let g:marked_autoquit = 0
+<
 ==============================================================================
 ABOUT                                           *marked-about*
 

--- a/doc/marked.txt
+++ b/doc/marked.txt
@@ -8,12 +8,12 @@ This plugin is only available on macOS and if 'compatible' is not set.
 ==============================================================================
 INTRODUCTION                                    *marked*
 
-Vim plugin for Marked 2 (http://marked2app.com), a previewer for Markdown
-files.
+Vim plugin for Marked (http://marked2app.com), a previewer for Markdown files.
+Supports Marked 1 and 2.
 
 Adds `:MarkedOpen`, `:MarkedQuit`, `:MarkedToggle`, and `:MarkedPreview`
 commands to Markdown buffers, allowing you to quickly open, close, and preview
-content in Marked 2.
+content in Marked.
 
 ==============================================================================
 COMMANDS                                        *marked-commands*
@@ -44,6 +44,12 @@ Call with a bang to prevent Marked from stealing focus from Vim.
 ==============================================================================
 CONFIGURATION                                   *marked-configuration*
 
+*g:marked_filetypes*
+
+The Marked application name. By default this is "Marked 2". If you are still
+using Marked.app version 1, add the following to your |vimrc|: >
+    let g:marked_app = "Marked"
+<
 *g:marked_filetypes*
 
 Vim FileTypes that can be opened by Marked and will load this plugin. The

--- a/doc/marked.txt
+++ b/doc/marked.txt
@@ -1,4 +1,4 @@
-*marked.txt*  Open Markdown in Marked 2.app.
+*marked.txt*  Open Markdown in Marked.
 Author: Joshua Priddle <jpriddle@me.com>
 License: MIT (see |vim-marked-license|)
 Version: 2.0.0
@@ -81,25 +81,7 @@ LICENSE                                         *vim-marked-license*
 
 MIT License
 
-Copyright (c) 2019 Joshua Priddle <jpriddle@me.com>
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+https://github.com/itspriddle/vim-marked/blob/master/LICENSE
 
 ==============================================================================
  vim:tw=78:et:ft=help:norl:

--- a/plugin/marked.vim
+++ b/plugin/marked.vim
@@ -48,6 +48,12 @@ function! s:MarkedQuit(force, path) abort
   execute printf("silent !osascript %s %s %s", applescript, a:force, shellescape(a:path, 1))
 endfunction
 
+function! s:MarkedQuitVimLeave() abort
+  if get(g:, "marked_autoquit", 1)
+    call s:MarkedQuit(1, "")
+  endif
+endfunction
+
 function! s:MarkedToggle(background_or_force_quit, path) abort
   if s:is_document_open(a:path)
     call s:MarkedQuit(a:background_or_force_quit, a:path)
@@ -106,7 +112,7 @@ endfunction
 augroup marked_commands
   autocmd!
   autocmd FileType    * call s:init(expand("<amatch>"))
-  autocmd VimLeavePre * call s:MarkedQuit(1, "")
+  autocmd VimLeavePre * call s:MarkedQuitVimLeave()
 augroup END
 
 let &cpo = s:save_cpo

--- a/plugin/marked.vim
+++ b/plugin/marked.vim
@@ -79,10 +79,10 @@ function! s:MarkedToggle(background_or_force_quit, path) abort
   endif
 endfunction
 
-function! s:MarkedPreview(line1, line2) abort
+function! s:MarkedPreview(background, line1, line2) abort
   let text = join(getline(a:line1, a:line2), "\n")
 
-  call s:marked_open_uri(0, "preview", { "text": text })
+  call s:marked_open_uri(a:background, "preview", { "text": text })
 endfunction
 
 function! s:is_document_open(path) abort
@@ -103,10 +103,10 @@ function! s:FileTypeInit(filetype) abort
 endfunction
 
 function! MarkedSetup() abort
-  command! -buffer -bang    MarkedOpen    call s:MarkedOpen(<bang>0, expand("%:p"))
-  command! -buffer -bang    MarkedQuit    call s:MarkedQuit(<bang>0, expand("%:p"))
-  command! -buffer -bang    MarkedToggle  call s:MarkedToggle(<bang>0, expand("%:p"))
-  command! -buffer -range=% MarkedPreview call s:MarkedPreview(<line1>, <line2>)
+  command! -buffer -bang          MarkedOpen    call s:MarkedOpen(<bang>0, expand("%:p"))
+  command! -buffer -bang          MarkedQuit    call s:MarkedQuit(<bang>0, expand("%:p"))
+  command! -buffer -bang          MarkedToggle  call s:MarkedToggle(<bang>0, expand("%:p"))
+  command! -buffer -bang -range=% MarkedPreview call s:MarkedPreview(<bang>0, <line1>, <line2>)
 endfunction
 
 " From the legend


### PR DESCRIPTION
- Adds `:MarkedPreview[!]` to send text to Marked as a preview
- Adds `g:marked_filetypes` to allow activating the plugin for other filetypes
- Adds `g:marked_autoquit` to allow disabling quitting Marked on Vim exit
- Adds `:MarkedQuit!` to quit Marked immediately
- Improves `:MarkedToggle` checking for open documents
- Switches to the MIT license 
- Improves documentation/README