### PR TITLE
Use system() over ! to open Marked

### DIFF
--- a/plugin/marked.vim
+++ b/plugin/marked.vim
@@ -37,7 +37,7 @@ function! s:OpenMarked(background)
 
   call s:AddDocument(l:filename)
 
-  silent exe "!open -a '".g:marked_app."' ".(a:background ? '-g' : '')." '".l:filename."'"
+  silent call system("open -a '".g:marked_app."' ".(a:background ? '-g' : '')." '".l:filename."'")
   redraw!
 endfunction
 


### PR DESCRIPTION
Resolves #31

Under some configurations `:!` will suspend Vim. This PR tries to work around that.